### PR TITLE
入力済みのresult_timesの削除

### DIFF
--- a/app/controllers/result_times_controller.rb
+++ b/app/controllers/result_times_controller.rb
@@ -1,5 +1,8 @@
 class ResultTimesController < ApplicationController
   def create
+    # 同じ日付が以前に入力されていた場合は先に削除しておく
+    User.find(current_user.id).result_time.where(record_date: record_date).destroy_all
+
     error_flg = false # エラーフラグ ループで保存する中で1つでもエラーがあると trueになる
 
     # 96ブロック分のループを回す 1週ごとに1レコード保存
@@ -24,9 +27,14 @@ class ResultTimesController < ApplicationController
 
   private
 
-  # record_dateを取得
+  # 入力を取得
   def result_time_params
     params.require(:result_time).permit(:record_date).merge(user_id: current_user.id)
+  end
+
+  # record_dateを取得
+  def record_date
+    params.require(:result_time).permit(:record_date)[:record_date]
   end
 
   # 96ブロックのidと入力されたown_time_idを取得

--- a/app/models/result_time.rb
+++ b/app/models/result_time.rb
@@ -26,4 +26,5 @@ class ResultTime < ApplicationRecord
   # t.integer :block,        null: false # ブロックid  ブロック1(5:00) ブロック2(5:15)...
 
   belongs_to :own_time
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,4 +27,5 @@ class User < ApplicationRecord
 
   has_many :projects
   has_one_attached :icon
+  has_many :result_time, dependent: :destroy
 end


### PR DESCRIPTION
# What
result_time入力時
同じ入力日のデータが以前にDBに保存されていた場合、いったん削除してから
今回の入力を保存する

# Why
統計データを算出する際に古いデータが邪魔になる
DBの要領圧迫の回避